### PR TITLE
No texture flag and export file structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Usage: `unreal2gltf.py -i <input path> -o <output path> [additional flags] `
 
 `-v`, `--version`: Get current version of the script and exit.
 
+`-nt`, `--notexture`: Export without textures
+
 ## Advanced Uage
 This script can be run directly from the commandline. Unreal Documentation shows how to run Python scripts directly from the commandline [here](https://docs.unrealengine.com/5.0/en-US/scripting-the-unreal-editor-using-python/#thecommandline).
 >[!WARNING]

--- a/unreal2gltf.py
+++ b/unreal2gltf.py
@@ -13,7 +13,7 @@ Usage: unreal2gltf.py -i <input path> -o <output path > [flags]
     -d, --subdirs=: List of subdirectories to export separated by commas. Ex. path1,path2,path3
     -nt, --notexture: Export without textures
 """
-VERSION_INFO= "unreal2gltf.py Version 1.1"
+VERSION_INFO= "unreal2gltf.py Version 1.2"
 
 # Actual Export Function
 def do_export(asset_directory: str, output_root: str, as_bin:bool, recurse:bool, no_texture:bool):


### PR DESCRIPTION
- Added support for --notexture. (-nt) - Some work flows such as migration Synty Assets to Godot are easier done if the GLB/GLTF does not have the texture files baked in.

- Ensured file structure on export is the same as the Unreal project.

- Updated Readme to reflect new feature

- Updated version to 1.2

Appreciate the work you did on the original and wanted to add the changes I've been using to make migrating Synty Assets to Godot much easier.